### PR TITLE
Update crate and fix text responses

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ aws_lambda_events = "0.4"
 # in favor of using netlify's fork lamedh-dev/aws-lambda-rust-runtime
 lamedh_http = "0.3"
 lamedh_runtime = "0.3"
+mime = "0.3"
+once_cell = "1.7"
 warp = "0.3"
 tower = "0.4"
 thiserror = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ aws_lambda_events = "0.4"
 # for the reason to move away from official awslabs/aws-lambda-rust-runtime
 # in favor of using netlify's fork lamedh-dev/aws-lambda-rust-runtime
 lamedh_http = "0.3"
-lamedh_runtime = "0.3"
 mime = "0.3"
 once_cell = "1.7"
 warp = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,8 @@ aws_lambda_events = "0.4"
 # Reference issue https://github.com/awslabs/aws-lambda-rust-runtime/issues/274 
 # for the reason to move away from official awslabs/aws-lambda-rust-runtime
 # in favor of using netlify's fork lamedh-dev/aws-lambda-rust-runtime
-netlify_lambda_http = "0.2"
+lamedh_http = "0.3"
+lamedh_runtime = "0.3"
 warp = "0.3"
 tower = "0.4"
 thiserror = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ async fn warp_body_as_lambda_body(warp_body: WarpBody, parts: &Parts) -> Result<
 
     // Attempt to determine the Content-Type
     let content_type: Option<&HeaderValue> = parts.headers.get("Content-Type");
-    let content_encoding: Option<&HeaderValue> = parts.headers.get("Content-EncEncoding");
+    let content_encoding: Option<&HeaderValue> = parts.headers.get("Content-Encoding");
 
     // If Content-Encoding is present, assume compression
     // If Content-Type is not present, don't assume is a string

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,11 @@ use lamedh_http::{
     lambda::{self, Context},
     Handler, Request, Response,
 };
+use mime::Mime;
+use once_cell::sync::Lazy;
+use std::collections::HashSet;
+use warp::http::response::Parts;
+use warp::http::HeaderValue;
 use warp::hyper::Body as WarpBody;
 
 type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
@@ -42,6 +47,42 @@ struct WarpHandler<
 
 type WarpHandlerFuture<Resp, Err> = Pin<Box<dyn Future<Output = Result<Resp, Err>> + 'static>>;
 
+static PLAINTEXT_MIMES: Lazy<HashSet<Mime>> = Lazy::new(|| {
+    vec![
+        mime::APPLICATION_JAVASCRIPT,
+        mime::APPLICATION_JAVASCRIPT_UTF_8,
+        mime::APPLICATION_JSON,
+    ]
+    .into_iter()
+    .collect()
+});
+
+async fn warp_body_as_lambda_body(warp_body: WarpBody, parts: &Parts) -> Result<LambdaBody, Error> {
+    // Concatenate all bytes into a single buffer
+    let raw_bytes = warp::hyper::body::to_bytes(warp_body).await?;
+
+    // Attempt to determine the Content-Type
+    let content_type: Option<&HeaderValue> = parts.headers.get("Content-Type");
+    let content_encoding: Option<&HeaderValue> = parts.headers.get("Content-EncEncoding");
+
+    // If Content-Encoding is present, assume compression
+    // If Content-Type is not present, don't assume is a string
+    let body = if let (Some(typ), None) = (content_type, content_encoding) {
+        let typ = typ.to_str()?;
+        let m = typ.parse::<Mime>()?;
+        if PLAINTEXT_MIMES.contains(&m) || m.type_() == mime::TEXT {
+            Some(String::from_utf8(raw_bytes.to_vec()).map(LambdaBody::Text)?)
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    // Not a text response, make binary
+    Ok(body.unwrap_or_else(|| LambdaBody::Binary(raw_bytes.to_vec())))
+}
+
 impl<F> Handler for WarpHandler<F>
 where
     F: tower::Service<WarpRequest, Response = WarpResponse, Error = Infallible> + 'static,
@@ -51,6 +92,7 @@ where
     type Fut = WarpHandlerFuture<Self::Response, Self::Error>;
 
     fn call(&mut self, event: Request, _context: Context) -> Self::Fut {
+        // Convert lambda request to warp request
         let (parts, in_body) = event.into_parts();
         let body = match in_body {
             LambdaBody::Binary(data) => WarpBody::from(data),
@@ -58,12 +100,17 @@ where
             LambdaBody::Empty => WarpBody::empty(),
         };
         let warp_request = WarpRequest::from_parts(parts, body);
+
+        // Call warp service with warp request, save future
         let warp_fut = self.0.call(warp_request);
-        let fut = async {
+
+        // Create lambda future
+        let fut = async move {
             let warp_response = warp_fut.await?;
-            let (parts, res_body) = warp_response.into_parts();
-            let raw_bytes = warp::hyper::body::to_bytes(res_body).await?;
-            let body = LambdaBody::from(raw_bytes.to_vec());
+            let (parts, res_body): (_, _) = warp_response.into_parts();
+
+            let body = warp_body_as_lambda_body(res_body, &parts).await?;
+
             let lambda_response = Response::from_parts(parts, body);
             Ok::<Self::Response, Self::Error>(lambda_response)
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,11 +2,11 @@ use core::future::Future;
 use std::convert::Infallible;
 use std::pin::Pin;
 
-pub use netlify_lambda_http as lambda_http;
+pub use lamedh_http as lambda_http;
 pub use warp;
 
 use aws_lambda_events::encodings::Body as LambdaBody;
-use netlify_lambda_http::{
+use lamedh_http::{
     handler,
     lambda::{self, Context},
     Handler, Request, Response,


### PR DESCRIPTION
There are two fixes here.

1. The Netlify fork is now called `lamedh_http` rather than `netlify_lambda_http`.
2. The code was refactored to attempt to intelligently return `LambdaBody::Text` when appropriate.

In a local setup using CDK and `aws-sam-cli`, the "Hello, World" example returns a base64-encoded version of the response body. I was able to determine that this is because of the unconditional conversion of the body into a `Vec<u8>` and creating a `LambdaBody` from that -- which will always be a `LambdaBody::Binary`.

The refactor inspects the `Content-Type` and `Content-Encoding` headers to attempt to determine whether the response is intended to be text or not. If so, it attempts to parse the bytes as a `String` and returns a `LambdaBody::Text`; otherwise, it returns a `LambdaBody::Binary`.

I considered other methods as well:

- Never erroring during the process and always falling back to a binary body. I decided against this because the errors should only happen if the response is already malformed, e.g. `Content-Type` is not a valid value or says the response is text but it fails to parse as such.
- Not inspecting the headers at all and just attempting to parse the bytes as a `String` and returning binary on failure. I decided against this because of the possibility that binary data could parse as a `String` despite being gibberish.

One possible downside of the current implementation is that it does assume the `String` is UTF-8. I am not sure there is a way around this, since Rust strings *are* UTF-8.