### PR TITLE
Use lambda_http 0.5 instead of fork

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,8 @@ categories = ["web-programming", "web-programming::http-server"]
 maintenance = { status = "experimental" }
 
 [dependencies]
-aws_lambda_events = "0.4"
-# Reference issue https://github.com/awslabs/aws-lambda-rust-runtime/issues/274 
-# for the reason to move away from official awslabs/aws-lambda-rust-runtime
-# in favor of using netlify's fork lamedh-dev/aws-lambda-rust-runtime
-lamedh_http = "0.3"
+lambda_http = "0.5"
+url = "2.2"
 mime = "0.3"
 once_cell = "1.7"
 warp = "0.3"

--- a/README.md
+++ b/README.md
@@ -2,11 +2,6 @@
 
 A super simple crate to let you use [warp filters](https://github.com/seanmonstar/warp) with [aws lambda runtime](https://github.com/awslabs/aws-lambda-rust-runtime)
 
-> Note: Using fork of [awslabs/aws-lambda-rust-runtime](https://github.com/awslabs/aws-lambda-rust-runtime) by Netlify devs [lamedh-dev/aws-lambda-rust-runtime](https://github.com/lamedh-dev/aws-lambda-rust-runtime)
-> Due to issue [#216](https://github.com/awslabs/aws-lambda-rust-runtime/issues/216) and an alternative from Netlify devs [#274](https://github.com/awslabs/aws-lambda-rust-runtime/issues/274)
-
-> `Warning: This is experimental and not production ready! uses non stable version of aws_lambda_rust_runtime`
-
 # Example
 
 Add `warp_lambda`, `warp` and `tokio` to your dependencies:

--- a/examples/hello_world/main.rs
+++ b/examples/hello_world/main.rs
@@ -5,11 +5,11 @@ use warp::Filter;
 async fn main() -> Result<()> {
     // Your warp routes (filters)
     let routes = warp::any().map(|| "Hello, World!");
-    // Convert them to a warp service (a tower service implmentation)
+    // Convert them to a warp service (a tower service implementation)
     // using `warp::service()`
     let warp_service = warp::service(routes);
     // The warp_lambda::run() function takes care of invoking the aws lambda runtime for you
     warp_lambda::run(warp_service)
         .await
-        .map_err(|err| anyhow!("An error occured `{:#?}`", err))
+        .map_err(|err| anyhow!("An error occurred `{:#?}`", err))
 }

--- a/examples/lambda_request_context/main.rs
+++ b/examples/lambda_request_context/main.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Result};
 use warp::Filter;
 
-use warp_lambda::lambda_http::request::RequestContext;
+use lambda_http::request::RequestContext;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -18,13 +18,15 @@ async fn main() -> Result<()> {
                 // Request context when invoked from an ALB event
                 RequestContext::Alb(alb) => format!("::ALB:: {:?}", alb),
                 // Request context when invoked from an API Gateway REST event
-                RequestContext::ApiGatewayV1(api_gw) => format!("::API_GW:: {:?}", api_gw),
+                RequestContext::ApiGatewayV1(api_gw1) => format!("::API_GW(V1):: {:?}", api_gw1),
                 // Request context when invoked from an API Gateway HTTP event
                 RequestContext::ApiGatewayV2(api_gw2) => format!("::API_GW(V2):: {:?}", api_gw2),
+                // Request context when invoked from a WebSocket event
+                RequestContext::WebSocket(ws) => format!("::WebSocket:: {:?}", ws),
             };
             format!("Hello {}! request context for debug {}", name, context)
         });
-    // Convert them to a warp service (a tower service implmentation)
+    // Convert them to a warp service (a tower service implementation)
     // using `warp::service()`
     let warp_service = warp::service(a_route);
     // The warp_lambda::run() function takes care of invoking the aws lambda runtime for you

--- a/examples/tracing/main.rs
+++ b/examples/tracing/main.rs
@@ -18,11 +18,11 @@ async fn main() -> Result<()> {
         .with(warp::log("warp_lambda::tracing::test"))
         .with(warp::trace::request());
 
-    // Convert them to a warp service (a tower service implmentation)
+    // Convert them to a warp service (a tower service implementation)
     // using `warp::service()`
     let warp_service = warp::service(routes);
     // The warp_lambda::run() function takes care of invoking the aws lambda runtime for you
     warp_lambda::run(warp_service)
         .await
-        .map_err(|err| anyhow!("An error occured `{:#?}`", err))
+        .map_err(|err| anyhow!("An error occurred `{:#?}`", err))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,50 +2,66 @@ use core::future::Future;
 use std::convert::Infallible;
 use std::pin::Pin;
 
-pub use lamedh_http as lambda_http;
+pub use lambda_http;
 pub use warp;
 
-use aws_lambda_events::encodings::Body as LambdaBody;
-use lamedh_http::{
-    handler,
-    lambda::{self, Context},
-    Handler, Request, Response,
+use lambda_http::http::response::Parts;
+use lambda_http::http::HeaderValue;
+use lambda_http::{
+    lambda_runtime, Adapter, Body as LambdaBody, Error as LambdaError, Request, RequestExt,
+    Response, Service,
 };
 use mime::Mime;
 use once_cell::sync::Lazy;
 use std::collections::HashSet;
-use warp::http::response::Parts;
-use warp::http::HeaderValue;
+use std::marker::PhantomData;
+use std::str::FromStr;
+use std::task::{Context, Poll};
 use warp::hyper::Body as WarpBody;
 
-type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
-
-pub async fn run<Svc>(warp_svc: Svc) -> Result<(), WarpHandlerError>
-where
-    Svc: tower::Service<WarpRequest, Response = WarpResponse, Error = Infallible> + 'static,
-{
-    lambda::run(handler(WarpHandler(warp_svc))).await?;
-    Ok(())
-}
-
-type WarpRequest = warp::http::Request<warp::hyper::Body>;
-type WarpResponse = warp::http::Response<warp::hyper::Body>;
+pub type WarpRequest = warp::http::Request<warp::hyper::Body>;
+pub type WarpResponse = warp::http::Response<warp::hyper::Body>;
 
 #[derive(thiserror::Error, Debug)]
-pub enum WarpHandlerError {
+pub enum WarpAdapterError {
     #[error("This may never occur, it's infallible!!")]
     Infallible(#[from] std::convert::Infallible),
     #[error("Warp error: `{0:#?}`")]
     HyperError(#[from] warp::hyper::Error),
     #[error("Unexpected error: `{0:#?}`")]
-    Unexpected(#[from] Error),
+    Unexpected(#[from] LambdaError),
 }
 
-struct WarpHandler<
-    Svc: tower::Service<WarpRequest, Response = WarpResponse, Error = Infallible> + 'static,
->(Svc);
+pub async fn run<'a, S>(service: S) -> Result<(), LambdaError>
+where
+    S: Service<WarpRequest, Response = WarpResponse, Error = Infallible> + Send + 'a,
+    S::Future: Send + 'a,
+{
+    lambda_runtime::run(Adapter::from(WarpAdapter::new(service))).await
+}
 
-type WarpHandlerFuture<Resp, Err> = Pin<Box<dyn Future<Output = Result<Resp, Err>> + 'static>>;
+#[derive(Clone)]
+pub struct WarpAdapter<'a, S>
+where
+    S: Service<WarpRequest, Response = WarpResponse, Error = Infallible>,
+    S::Future: Send + 'a,
+{
+    warp_service: S,
+    _phantom_data: PhantomData<&'a WarpResponse>,
+}
+
+impl<'a, S> WarpAdapter<'a, S>
+where
+    S: Service<WarpRequest, Response = WarpResponse, Error = Infallible>,
+    S::Future: Send + 'a,
+{
+    pub fn new(warp_service: S) -> Self {
+        Self {
+            warp_service,
+            _phantom_data: PhantomData,
+        }
+    }
+}
 
 static PLAINTEXT_MIMES: Lazy<HashSet<Mime>> = Lazy::new(|| {
     vec![
@@ -57,7 +73,10 @@ static PLAINTEXT_MIMES: Lazy<HashSet<Mime>> = Lazy::new(|| {
     .collect()
 });
 
-async fn warp_body_as_lambda_body(warp_body: WarpBody, parts: &Parts) -> Result<LambdaBody, Error> {
+async fn warp_body_as_lambda_body(
+    warp_body: WarpBody,
+    parts: &Parts,
+) -> Result<LambdaBody, LambdaError> {
     // Concatenate all bytes into a single buffer
     let raw_bytes = warp::hyper::body::to_bytes(warp_body).await?;
 
@@ -83,31 +102,42 @@ async fn warp_body_as_lambda_body(warp_body: WarpBody, parts: &Parts) -> Result<
     Ok(body.unwrap_or_else(|| LambdaBody::Binary(raw_bytes.to_vec())))
 }
 
-impl<F> Handler for WarpHandler<F>
+impl<'a, S> Service<Request> for WarpAdapter<'a, S>
 where
-    F: tower::Service<WarpRequest, Response = WarpResponse, Error = Infallible> + 'static,
+    S: Service<WarpRequest, Response = WarpResponse, Error = Infallible> + 'a,
+    S::Future: Send + 'a,
 {
     type Response = Response<LambdaBody>;
-    type Error = Error;
-    type Fut = WarpHandlerFuture<Self::Response, Self::Error>;
+    type Error = LambdaError;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'a>>;
 
-    #[tracing::instrument(
-        name = "warp_lambda::call",
-        skip(self, event, context),
-        fields(request_id = ?context.request_id)
-    )]
-    fn call(&mut self, event: Request, context: Context) -> Self::Fut {
-        // Convert lambda request to warp request
-        let (parts, in_body) = event.into_parts();
-        let body = match in_body {
-            LambdaBody::Binary(data) => WarpBody::from(data),
-            LambdaBody::Text(text) => WarpBody::from(text),
+    fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        core::task::Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: Request) -> Self::Future {
+        let query_params = req.query_string_parameters();
+
+        let (mut parts, body) = req.into_parts();
+        let body = match body {
             LambdaBody::Empty => WarpBody::empty(),
+            LambdaBody::Text(t) => WarpBody::from(t.into_bytes()),
+            LambdaBody::Binary(b) => WarpBody::from(b),
         };
+
+        let mut uri = format!("http://{}{}", "127.0.0.1", parts.uri.path());
+
+        if !query_params.is_empty() {
+            append_querystring_from_map(&mut uri, query_params.iter());
+        }
+
+        parts.uri = warp::hyper::Uri::from_str(uri.as_str())
+            .map_err(|e| e)
+            .unwrap();
         let warp_request = WarpRequest::from_parts(parts, body);
 
         // Call warp service with warp request, save future
-        let warp_fut = self.0.call(warp_request);
+        let warp_fut = self.warp_service.call(warp_request);
 
         // Create lambda future
         let fut = async move {
@@ -121,4 +151,16 @@ where
         };
         Box::pin(fut)
     }
+}
+
+fn append_querystring_from_map<'a, I>(uri: &mut String, from_query_params: I)
+where
+    I: Iterator<Item = (&'a str, &'a str)>,
+{
+    uri.push('?');
+    let mut serializer = url::form_urlencoded::Serializer::new(String::new());
+    for (key, value) in from_query_params {
+        serializer.append_pair(key, value);
+    }
+    uri.push_str(serializer.finish().as_str())
 }


### PR DESCRIPTION
This PR uses the official lambda_http release 0.5 which fixes https://github.com/awslabs/aws-lambda-rust-runtime/issues/274 and updates the warp adapter to implement `tower::Service` directly now that the lambda http handler has been removed.